### PR TITLE
URL Cleanup

### DIFF
--- a/hello-worlds/build.gradle
+++ b/hello-worlds/build.gradle
@@ -18,6 +18,6 @@ configurations {
 repositories {
     mavenCentral()
 	mavenLocal()
-	mavenRepo urls: "http://maven.springframework.org/release"
+	mavenRepo urls: "https://maven.springframework.org/release"
 }
 

--- a/hello-worlds/pom.xml
+++ b/hello-worlds/pom.xml
@@ -22,7 +22,7 @@
     <repository>
       <id>spring-maven-release</id>
       <name>Spring Maven Release Repository</name>
-      <url>http://maven.springframework.org/release</url>
+      <url>https://maven.springframework.org/release</url>
     </repository>
     <repository>
       <id>spring-maven-snapshot</id>
@@ -30,16 +30,16 @@
       <snapshots>
         <enabled>true</enabled>
       </snapshots>
-      <url>http://maven.springframework.org/snapshot</url>
+      <url>https://maven.springframework.org/snapshot</url>
     </repository>
     <repository>
       <id>spring-maven-milestone</id>
       <name>Spring Maven Milestone Repository</name>
-      <url>http://maven.springframework.org/milestone</url>
+      <url>https://maven.springframework.org/milestone</url>
     </repository>
     <repository>
       <id>neo4j-public-repository</id>
-      <url>http://m2.neo4j.org/</url>
+      <url>https://m2.neo4j.org/</url>
       <name>Publicly available Maven 2 repository for Neo4j</name>
     </repository>
   </repositories>
@@ -48,12 +48,12 @@
     <pluginRepository>
       <id>spring-maven-release</id>
       <name>Spring Maven Release Repository</name>
-      <url>http://maven.springframework.org/release</url>
+      <url>https://maven.springframework.org/release</url>
     </pluginRepository>
     <pluginRepository>
       <id>spring-maven-milestone</id>
       <name>Spring Maven Milestone Repository</name>
-      <url>http://maven.springframework.org/milestone</url>
+      <url>https://maven.springframework.org/milestone</url>
     </pluginRepository>
   </pluginRepositories>
 

--- a/imdb/pom.xml
+++ b/imdb/pom.xml
@@ -18,7 +18,7 @@
     <repository>
       <id>spring-maven-release</id>
       <name>Spring Maven Release Repository</name>
-      <url>http://maven.springframework.org/release</url>
+      <url>https://maven.springframework.org/release</url>
     </repository>
     <repository>
       <id>spring-maven-snapshot</id>
@@ -26,16 +26,16 @@
       <snapshots>
         <enabled>true</enabled>
       </snapshots>
-      <url>http://maven.springframework.org/snapshot</url>
+      <url>https://maven.springframework.org/snapshot</url>
     </repository>
     <repository>
       <id>spring-maven-milestone</id>
       <name>Spring Maven Milestone Repository</name>
-      <url>http://maven.springframework.org/milestone</url>
+      <url>https://maven.springframework.org/milestone</url>
     </repository>
     <repository>
       <id>neo4j-public-repository</id>
-      <url>http://m2.neo4j.org/</url>
+      <url>https://m2.neo4j.org/</url>
       <name>Publicly available Maven 2 repository for Neo4j</name>
     </repository>
   </repositories>
@@ -43,12 +43,12 @@
     <pluginRepository>
       <id>spring-maven-release</id>
       <name>Spring Maven Release Repository</name>
-      <url>http://maven.springframework.org/release</url>
+      <url>https://maven.springframework.org/release</url>
     </pluginRepository>
     <pluginRepository>
       <id>spring-maven-milestone</id>
       <name>Spring Maven Milestone Repository</name>
-      <url>http://maven.springframework.org/milestone</url>
+      <url>https://maven.springframework.org/milestone</url>
     </pluginRepository>
   </pluginRepositories>
   <dependencies>

--- a/myrestaurants-original/pom.xml
+++ b/myrestaurants-original/pom.xml
@@ -17,12 +17,12 @@
         <repository>
             <id>spring-maven-release</id>
             <name>Spring Maven Release Repository</name>
-            <url>http://maven.springframework.org/release</url>
+            <url>https://maven.springframework.org/release</url>
         </repository>
         <repository>
             <id>spring-maven-milestone</id>
             <name>Spring Maven Milestone Repository</name>
-            <url>http://maven.springframework.org/milestone</url>
+            <url>https://maven.springframework.org/milestone</url>
         </repository>
 		<repository>
             <id>JBoss Repo</id>
@@ -34,12 +34,12 @@
         <pluginRepository>
             <id>spring-maven-release</id>
             <name>Spring Maven Release Repository</name>
-            <url>http://maven.springframework.org/release</url>
+            <url>https://maven.springframework.org/release</url>
         </pluginRepository>
         <pluginRepository>
             <id>spring-maven-milestone</id>
             <name>Spring Maven Milestone Repository</name>
-            <url>http://maven.springframework.org/milestone</url>
+            <url>https://maven.springframework.org/milestone</url>
         </pluginRepository>
 	</pluginRepositories>
 	<dependencies>

--- a/myrestaurants-social/pom.xml
+++ b/myrestaurants-social/pom.xml
@@ -18,12 +18,12 @@
         <repository>
             <id>spring-maven-release</id>
             <name>Spring Maven Release Repository</name>
-            <url>http://maven.springframework.org/release</url>
+            <url>https://maven.springframework.org/release</url>
         </repository>
         <repository>
             <id>spring-maven-milestone</id>
             <name>Spring Maven Milestone Repository</name>
-            <url>http://maven.springframework.org/milestone</url>
+            <url>https://maven.springframework.org/milestone</url>
         </repository>
 		<repository>
 			<id>spring-maven-snapshot</id>
@@ -31,7 +31,7 @@
 				<enabled>true</enabled>
 			</snapshots>
 			<name>Springframework Maven SNAPSHOT Repository</name>
-			<url>http://maven.springframework.org/snapshot</url>
+			<url>https://maven.springframework.org/snapshot</url>
         </repository>
 		<repository>
             <id>JBoss Repo</id>
@@ -43,12 +43,12 @@
         <pluginRepository>
             <id>spring-maven-release</id>
             <name>Spring Maven Release Repository</name>
-            <url>http://maven.springframework.org/release</url>
+            <url>https://maven.springframework.org/release</url>
         </pluginRepository>
         <pluginRepository>
             <id>spring-maven-milestone</id>
             <name>Spring Maven Milestone Repository</name>
-            <url>http://maven.springframework.org/milestone</url>
+            <url>https://maven.springframework.org/milestone</url>
         </pluginRepository>
 	</pluginRepositories>
 	<dependencies>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were fixed successfully.

* http://m2.neo4j.org/ migrated to:  
  https://m2.neo4j.org/ ([https](https://m2.neo4j.org/) result 301).
* http://maven.springframework.org/milestone migrated to:  
  https://maven.springframework.org/milestone ([https](https://maven.springframework.org/milestone) result 302).
* http://maven.springframework.org/release migrated to:  
  https://maven.springframework.org/release ([https](https://maven.springframework.org/release) result 302).
* http://maven.springframework.org/snapshot migrated to:  
  https://maven.springframework.org/snapshot ([https](https://maven.springframework.org/snapshot) result 302).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/maven-v4_0_0.xsd
* http://maven.apache.org/xsd/maven-4.0.0.xsd
* http://www.w3.org/2001/XMLSchema-instance